### PR TITLE
workaround using classic JS modules

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,13 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <!-- workaround to use OpenCage OL plugin -->
+    <link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@opencage/ol-opencage-geosearch/ol-opencage-geosearch.css" />
+    <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.14.1/build/ol.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@opencage/geosearch-bundle"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@opencage/ol-opencage-geosearch"></script>
+    <!-- ./workaround to use OpenCage OL plugin -->
     <title>Web GIS Portal</title>
   </head>
   <body>

--- a/src/MyMap.js
+++ b/src/MyMap.js
@@ -20,7 +20,7 @@ import LayerGroup from 'ol/layer/Group';
 import LayerSwitcherImage from "ol-ext/control/LayerSwitcherImage";
 
 /* OpenCage GeoSearch */
-import OpenCageGeosearchControl from '@opencage/ol-opencage-geosearch';
+// import OpenCageGeosearchControl from '@opencage/ol-opencage-geosearch';
 
 let layers = [];
 let basemaps;
@@ -138,6 +138,7 @@ function MapWrapper(props) {
             position: 'topright',
         };
 
+        // eslint-disable-next-line no-undef
         var controlGeosearch = new OpenCageGeosearchControl(options);
         initialMap.addControl(controlGeosearch);
     }, [])


### PR DESCRIPTION
This PR fixes the issue using the OpenCage Geosearch Plugin for OpenLayers. This is a workaround using OL and the OpenCage plugin with classic JS modules in the browser.

It loads both OpenLayers and the plugin directly in the index.html so it can be used later on in the application.

<img width="1795" alt="image" src="https://user-images.githubusercontent.com/1741320/185503705-afee2587-c8b5-46cd-92de-f0381ebfcc86.png">
